### PR TITLE
Always return something for compatibility with “LoadElement”

### DIFF
--- a/ddGetMultipleField.php
+++ b/ddGetMultipleField.php
@@ -319,4 +319,5 @@ if (isset($string) && strlen($string) > 0){
 		return $result;
 	}
 }
+return false;
 ?>

--- a/ddGetMultipleField.php
+++ b/ddGetMultipleField.php
@@ -319,5 +319,6 @@ if (isset($string) && strlen($string) > 0){
 		return $result;
 	}
 }
-return false;
+// выдать пустой результат, еслы ранее не было завершения сниппета.
+return '';
 ?>


### PR DESCRIPTION
если нет результатов вывода сниппета по каким либо причинам, выдается результирующим текстом единица (результат успешного выполнения скрипта с пустыми данными), а должно быть пусто - ""